### PR TITLE
Fix inverted dimmer text color

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -153,7 +153,7 @@ body.dimmable > .dimmer {
   background-color: @invertedBackgroundColor;
 }
 .ui.inverted.dimmer > .content > * {
-  color: @textColor;
+  color: @invertedTextColor;
 }
 
 /*--------------


### PR DESCRIPTION
The definition references the wrong variable `@textColor` instead of `@invertedTextColor` which is defined in https://github.com/Semantic-Org/Semantic-UI/blob/ebb1cab098cad4509d8b173bd1d185b7472711f6/src/themes/default/modules/dimmer.variables#L54.